### PR TITLE
ci: fix scraping permission

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  actions: read  # required for actions-timeline
 
 concurrency:
   group: "pages"
@@ -19,8 +20,6 @@ jobs:
   actions-timeline:
     needs: [build, deploy, call-scraping-workflow]
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
     steps:
       - uses: Kesin11/actions-timeline@v1
 


### PR DESCRIPTION

> Invalid workflow file: .github/workflows/pages.yml#L62
The workflow is not valid. .github/workflows/pages.yml (Line: 62, Col: 3): Error calling workflow 'korosuke613/homepage-2nd/.github/workflows/scraping.yaml@8311359fa31c4eb312918594c9f9f07cf73bd6ce'. The workflow is requesting 'actions: read', but is only allowed 'actions: none'.
