### PR TITLE
ci: remove restore keys

### DIFF
--- a/.github/workflows/vrt-regression.yaml
+++ b/.github/workflows/vrt-regression.yaml
@@ -86,7 +86,6 @@ jobs:
         with:
           path: src/tests/vrt/snapshots
           key: vrt-${{ vars.RECENT_ARTIFACTS_SHA256 }}
-          restore-keys: vrt-
 
       - name: Check snapshot exists
         if: ${{ !inputs.skip }}


### PR DESCRIPTION
because, the test oracle should be a screenshot of the latest deployed page.