### PR TITLE
ci: using actions/cache/save for vrt-init

### DIFF
--- a/.github/workflows/vrt-init.yaml
+++ b/.github/workflows/vrt-init.yaml
@@ -41,12 +41,11 @@ jobs:
         run: npx playwright install chromium --with-deps
 
       - name: Cache VRT snapshots
-        uses: actions/cache@v3
+        uses: actions/cache/save@v3
         id: vrt-cache
         with:
           path: src/tests/vrt/snapshots
           key: vrt-${{ inputs.sha || vars.RECENT_ARTIFACTS_SHA256 }}
-          restore-keys: vrt-
       
       - name: Run VRT init
         run: |


### PR DESCRIPTION
because: not necessary to restore