### PR TITLE
fix: articles are in descending order of pubDate when multiple added

### DIFF
--- a/tools/updateZennJson.ts
+++ b/tools/updateZennJson.ts
@@ -1,5 +1,4 @@
 import Parser from "rss-parser";
-import { json } from "stream/consumers";
 const parser = new Parser();
 import fs from "node:fs";
 // eslint-disable-next-line node/no-unpublished-import
@@ -38,7 +37,8 @@ const updateZennJson = (
 ): ZennJson => {
   const updatedAt = new Date(updatedAtString);
 
-  for (const r of rss) {
+  // 取得した RSS は新しい順に並んでいるので、古い順に並び替える
+  for (const r of rss.reverse()) {
     if (updatedAt > new Date(r.isoDate)) {
       console.info(`info: skip ${r.title}`);
       continue;


### PR DESCRIPTION
Fixed a problem that when multiple articles are added, the added articles are in descending order of pubDate.

ex #491 
```diff json
    "productivity-weekly-20231101": {
      "title": "ActionsでArm、GPUランナーが使えるようになるよ：Productivity Weekly (2023-11-01号)",
      "ogpImageUrl": "...",
      "pubDate": "2023-11-13T01:00:00.000Z",
      "url": "https://zenn.dev/cybozu_ept/articles/productivity-weekly-20231101"
+    },
+    "practice-vrt-using-github-actions-cache": {
+      "title": "GitHub Actions のキャッシュを使った VRT のすゝめ",
+      "ogpImageUrl": "...",
+      "pubDate": "2023-12-12T03:00:00.000Z",
+      "url": "https://zenn.dev/cybozu_ept/articles/practice-vrt-using-github-actions-cache"
+    },
+    "productivity-weekly-20231122": {
+      "title": "ECRのプルスルーキャッシュ強化。LambdaがNode.js v20対応｜Productivity Weekly(2023-11-22号)",
+      "ogpImageUrl": "...",
+      "pubDate": "2023-12-12T01:00:00.000Z",
+      "url": "https://zenn.dev/cybozu_ept/articles/productivity-weekly-20231122"
    }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - Zennの記事情報更新ツールに、RSSフィードの処理順序を逆にする変更を実施。

- **リファクタ**
  - 不要な`json`モジュールのインポートを削除。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->