### PR TITLE
ci: fix renovate author

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -71,6 +71,4 @@ jobs:
           # This enables the cache -- if this is set, it's not necessary to add it to renovate.json.
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
-          RENOVATE_USERNAME: 'renovate[bot]'
-          RENOVATE_GIT_AUTHOR: 'Renovate Bot <bot@renovateapp.com>'
           LOG_LEVEL: 'debug'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **設定変更**
  - Renovate Botの識別情報とログレベルに関する設定から、`RENOVATE_USERNAME`と`RENOVATE_GIT_AUTHOR`の宣言を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->