### PR TITLE
ci: update renovate version

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -63,7 +63,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: renovatebot/github-action@f9c81dddc9b589e4e6ae0326d1e36f6bc415d230 # v39.2.4
+      - uses: renovatebot/github-action@42c1d3cb1d1ca891765626ba71cdff5e757258de # v40.0.2
         with:
           configurationFile: renovate.json5
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- GitHubアクション`renovatebot/github-action`のバージョンをv39.2.4からv40.0.2へ更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->