### PR TITLE
fix: remove unnecessary words for newer post

### DIFF
--- a/src/components/Pagenation.tsx
+++ b/src/components/Pagenation.tsx
@@ -46,9 +46,7 @@ export const NewerOlderPagination = (props: INewerOlderPaginationProps) => {
   return (
     <div className="flex justify-center gap-8">
       {props.page.url.prev && (
-        <a href={path.join(AppConfig.base, props.page.url.prev)}>
-          ← Newer Posts
-        </a>
+        <a href={path.join(AppConfig.base, props.page.url.prev)}>←</a>
       )}
       {props.page.lastPage !== 1 && (
         <div className="hidden justify-center gap-4 sm:flex">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- ページネーションのテキストを「新しい投稿」から左矢印のシンボル「←」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->