### PR TITLE
refactor: pagenation components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "@storybook/react": "7.6.17",
         "@storybook/react-vite": "7.6.17",
         "@storybook/test": "7.6.17",
+        "@storybook/testing-library": "0.2.2",
         "@types/react": "18.2.61",
         "@typescript-eslint/eslint-plugin": "7.1.0",
         "@typescript-eslint/parser": "7.1.0",
@@ -8181,6 +8182,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/@storybook/testing-library": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.2.2.tgz",
+      "integrity": "sha512-L8sXFJUHmrlyU2BsWWZGuAjv39Jl1uAqUHdxmN42JY15M4+XCMjGlArdCCjDe1wpTSW6USYISA9axjZojgtvnw==",
+      "dev": true,
+      "dependencies": {
+        "@testing-library/dom": "^9.0.0",
+        "@testing-library/user-event": "^14.4.0",
+        "ts-dedent": "^2.2.0"
+      }
+    },
+    "node_modules/@storybook/testing-library/node_modules/@testing-library/user-event": {
+      "version": "14.5.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@storybook/theming": {
@@ -38961,6 +38986,26 @@
         "@vitest/spy": "^0.34.1",
         "chai": "^4.3.7",
         "util": "^0.12.4"
+      }
+    },
+    "@storybook/testing-library": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@storybook/testing-library/-/testing-library-0.2.2.tgz",
+      "integrity": "sha512-L8sXFJUHmrlyU2BsWWZGuAjv39Jl1uAqUHdxmN42JY15M4+XCMjGlArdCCjDe1wpTSW6USYISA9axjZojgtvnw==",
+      "dev": true,
+      "requires": {
+        "@testing-library/dom": "^9.0.0",
+        "@testing-library/user-event": "^14.4.0",
+        "ts-dedent": "^2.2.0"
+      },
+      "dependencies": {
+        "@testing-library/user-event": {
+          "version": "14.5.2",
+          "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
+          "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
+          "dev": true,
+          "requires": {}
+        }
       }
     },
     "@storybook/theming": {

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "@storybook/react": "7.6.17",
     "@storybook/react-vite": "7.6.17",
     "@storybook/test": "7.6.17",
+    "@storybook/testing-library": "0.2.2",
     "@types/react": "18.2.61",
     "@typescript-eslint/eslint-plugin": "7.1.0",
     "@typescript-eslint/parser": "7.1.0",

--- a/src/components/NewerOlderPagination/NewerOlderPagination.stories.tsx
+++ b/src/components/NewerOlderPagination/NewerOlderPagination.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { expect } from "@storybook/test";
+import { within } from "@storybook/testing-library";
+import { NewerOlderPagination } from ".";
+import type { GlobalArgs } from ".storybook/preview";
+
+const metaData: Meta<typeof NewerOlderPagination> & GlobalArgs = {
+  title: "NewerOlderPagination",
+  component: NewerOlderPagination,
+  args: {
+    Global_disableDecorator: true,
+  },
+};
+
+export default metaData;
+
+export const Default: StoryObj<typeof NewerOlderPagination> = {
+  args: {
+    page: {
+      data: [], // Add an empty array for the 'data' property
+      start: 1, // Add a default value for the 'start' property
+      end: 5, // Add a default value for the 'end' property
+      total: 5, // Add a default value for the 'total' property
+      size: 5, // Add a default value for the 'size' property
+      currentPage: 3,
+      lastPage: 5,
+      url: {
+        current: "/blog/3",
+        prev: "/blog/2",
+        next: "/blog/4",
+      },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const links = canvas.getAllByRole("link");
+
+    const prev = links[0];
+    const next = links[links.length - 1];
+
+    expect(prev).toHaveAttribute("href", "/blog/2");
+    expect(next).toHaveAttribute("href", "/blog/4");
+
+    expect(canvas.getByText("1")).toHaveAttribute("href", "/blog");
+    expect(canvas.getByText("2")).toHaveAttribute("href", "/blog/2");
+    expect(canvas.getByText("4")).toHaveAttribute("href", "/blog/4");
+    expect(canvas.getByText("5")).toHaveAttribute("href", "/blog/5");
+  },
+};
+
+export const FirstPage: StoryObj<typeof NewerOlderPagination> = {
+  args: {
+    page: {
+      data: [], // Add an empty array for the 'data' property
+      start: 1, // Add a default value for the 'start' property
+      end: 0, // Add a default value for the 'end' property
+      total: 0, // Add a default value for the 'total' property
+      size: 0, // Add a default value for the 'size' property
+      currentPage: 1,
+      lastPage: 5,
+      url: {
+        current: "/blog/",
+        prev: undefined,
+        next: "/blog/2",
+      },
+    },
+  },
+
+  play: async ({ canvasElement }) => {
+    // 最初のページなので「←」のリンクがないことを確認
+    const canvas = within(canvasElement);
+    const links = canvas.getAllByRole("link");
+    expect(links[0]).not.toHaveTextContent("←");
+  },
+};
+
+export const LastPage: StoryObj<typeof NewerOlderPagination> = {
+  args: {
+    page: {
+      data: [], // Add an empty array for the 'data' property
+      start: 1, // Add a default value for the 'start' property
+      end: 0, // Add a default value for the 'end' property
+      total: 0, // Add a default value for the 'total' property
+      size: 0, // Add a default value for the 'size' property
+      currentPage: 5,
+      lastPage: 5,
+      url: {
+        current: "/blog/5",
+        prev: "/blog/2",
+        next: undefined,
+      },
+    },
+  },
+
+  play: async ({ canvasElement }) => {
+    // 最後のページなので「→」のリンクがないことを確認
+    const canvas = within(canvasElement);
+    const links = canvas.getAllByRole("link");
+    expect(links[links.length - 1]).not.toHaveTextContent("→");
+  },
+};
+
+export const SinglePage: StoryObj<typeof NewerOlderPagination> = {
+  args: {
+    page: {
+      data: [], // Add an empty array for the 'data' property
+      start: 1, // Add a default value for the 'start' property
+      end: 1, // Add a default value for the 'end' property
+      total: 1, // Add a default value for the 'total' property
+      size: 1, // Add a default value for the 'size' property
+      currentPage: 1,
+      lastPage: 1,
+      url: {
+        current: "/blog",
+        prev: undefined,
+        next: undefined,
+      },
+    },
+  },
+
+  play: async ({ canvasElement }) => {
+    // ページが1ページしかないのでリンクがないことを確認
+    const canvas = within(canvasElement);
+    const links = canvas.queryByRole("link");
+    expect(links).not.toBeInTheDocument();
+  },
+};

--- a/src/components/NewerOlderPagination/index.tsx
+++ b/src/components/NewerOlderPagination/index.tsx
@@ -1,8 +1,5 @@
-import path from "path";
 import type { Page } from "astro";
 import type { ReactNode } from "react";
-
-import { AppConfig } from "@/utils/AppConfig";
 
 type INewerOlderPaginationProps = {
   page: Page;
@@ -12,7 +9,8 @@ const createPageNumberLink = (page: Page) => {
   const items: ReactNode[] = [];
   let currentPageBaseUrl = page.url.current;
   if (page.currentPage !== 1) {
-    currentPageBaseUrl = path.dirname(currentPageBaseUrl);
+    currentPageBaseUrl = currentPageBaseUrl.split("/").slice(0, -1).join("/");
+    console.log(currentPageBaseUrl);
   }
 
   for (let i = 1; i <= page.lastPage; i += 1) {
@@ -23,12 +21,10 @@ const createPageNumberLink = (page: Page) => {
         </span>,
       );
     } else if (i === 1) {
-      items.push(
-        <a href={path.join(AppConfig.base, currentPageBaseUrl)}>{i}</a>,
-      );
+      items.push(<a href={currentPageBaseUrl}>{i}</a>);
     } else {
       items.push(
-        <a href={path.join(AppConfig.base, currentPageBaseUrl, i.toString())}>
+        <a href={`${currentPageBaseUrl}/${i.toString()}`.replaceAll("//", "/")}>
           {i}
         </a>,
       );
@@ -45,31 +41,14 @@ export const NewerOlderPagination = (props: INewerOlderPaginationProps) => {
 
   return (
     <div className="flex justify-center gap-8">
-      {props.page.url.prev && (
-        <a href={path.join(AppConfig.base, props.page.url.prev)}>←</a>
-      )}
+      {props.page.url.prev && <a href={props.page.url.prev}>←</a>}
       {props.page.lastPage !== 1 && (
         <div className="hidden justify-center gap-4 sm:flex">
           {createPageNumberLink(props.page)}
         </div>
       )}
 
-      {props.page.url.next && (
-        <a href={path.join(AppConfig.base, props.page.url.next)}>→</a>
-      )}
+      {props.page.url.next && <a href={props.page.url.next}>→</a>}
     </div>
   );
 };
-
-type IPaginationHeaderProps = {
-  title: ReactNode;
-  description: string;
-};
-
-export const PaginationHeader = (props: IPaginationHeaderProps) => (
-  <div className="text-center">
-    <h1 className="text-3xl font-bold">{props.title}</h1>
-
-    <div className="mt-3 text-gray-200">{props.description}</div>
-  </div>
-);

--- a/src/components/PaginationHeader/PaginationHeader.stories.tsx
+++ b/src/components/PaginationHeader/PaginationHeader.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { PaginationHeader } from ".";
+import type { GlobalArgs } from ".storybook/preview";
+
+const metaData: Meta<typeof PaginationHeader> & GlobalArgs = {
+  title: "PaginationHeader",
+  component: PaginationHeader,
+  args: {
+    Global_disableDecorator: true,
+  },
+};
+
+export default metaData;
+
+export const Default: StoryObj<typeof PaginationHeader> = {
+  args: {
+    title: "Blog",
+    description: "外部のブログ記事（自動更新）",
+  },
+};

--- a/src/components/PaginationHeader/index.tsx
+++ b/src/components/PaginationHeader/index.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+type IPaginationProps = {
+  title: ReactNode;
+  description: string;
+};
+
+export const PaginationHeader = (props: IPaginationProps) => (
+  <>
+    <h1 className="text-3xl font-bold text-center">{props.title}</h1>
+    <div className="mt-3 text-gray-200 text-center">{props.description}</div>
+  </>
+);

--- a/src/templates/Blogs.astro
+++ b/src/templates/Blogs.astro
@@ -1,9 +1,7 @@
 ---
 import { BlogGallery } from '@/components/BlogGallery';
-import {
-  NewerOlderPagination,
-  PaginationHeader,
-} from '@/components/Pagenation';
+import { NewerOlderPagination } from '@/components/NewerOlderPagination';
+import { PaginationHeader } from '@/components/PaginationHeader';
 import { Section } from '@/components/Section';
 import { Tag } from '@/components/Tag';
 import { Title } from '@/components/Title/index';

--- a/src/templates/Content.astro
+++ b/src/templates/Content.astro
@@ -1,8 +1,6 @@
 ---
-import {
-  NewerOlderPagination,
-  PaginationHeader,
-} from '@/components/Pagenation';
+import { PaginationHeader } from '@/components/PaginationHeader';
+import { NewerOlderPagination } from '@/components/NewerOlderPagination';
 import { PostGallery } from '@/components/PostGallery';
 import { Section } from '@/components/Section';
 import { Tag } from '@/components/Tag';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - `NewerOlderPagination` コンポーネントと `PaginationHeader` コンポーネントのためのストーリーを追加しました。これにより、異なるシナリオでのページネーションとヘッダーの表示を確認できます。
  - ページネーションのリンク生成ロジックを更新し、よりシンプルなリンク構築に改善しました。

- **バグ修正**
  - `NewerOlderPagination` コンポーネントで不要なインポートを削除し、`currentPageBaseUrl` の割り当てをリファクタリングしました。

- **リファクタ**
  - `Blogs.astro` と `Content.astro` ファイルでページネーションコンポーネントのインポートを再編成しました。

- **依存関係の更新**
  - 新しい依存関係 `@storybook/testing-library` とその依存関係を追加しました。また、`@testing-library/user-event` をバージョン 14.5.2 に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->