### PR TITLE
fix: don't update db if update diff exists

### DIFF
--- a/db/updateGA4Data.ts
+++ b/db/updateGA4Data.ts
@@ -30,8 +30,7 @@ const updateAstroDB = async <T extends TableType>(
   let isChange = false;
 
   const queryData = getQueryData(category, latestData, currentData, primaryKey);
-  const updateQuery = [];
-  if (updateQuery.length > 0) {
+  if (queryData.updateData.length > 0) {
     const batchRes: Array<Array<{ updatedId: string }>> = await db.batch(
       queryData.updateData.map(updateFunc) as unknown as [
         BatchItem<"sqlite">,


### PR DESCRIPTION
example

```
[Zenns] update: {"pagePath":"/cybozu_ept/articles/productivity-weekly-20230125","screenPageViews":20}
[Zenns] update: {"pagePath":"/cybozu_ept/articles/productivity-weekly-20221012","screenPageViews":18}
[Zenns] update: {"pagePath":"/cybozu_ept/articles/productivity-weekly-20221026","screenPageViews":11}
[Zenns] update: {"pagePath":"/korosuke613/articles/productivity-weekly-20210421","screenPageViews":7}
[Zenns] update: {"pagePath":"/korosuke613/articles/productivity-weekly-20210616","screenPageViews":5}
[Zenns / update]: No data to update.
[Zenns / insert]: No data to insert.
```