### PR TITLE
ci: fix EACCES on renovatebot/github-action

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -63,10 +63,17 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      - name: Determine current user
+        id: id
+        run: |
+          echo "user=$(id -u)" >> $GITHUB_OUTPUT
+          echo "group=$(id -g)" >> $GITHUB_OUTPUT
+
       - uses: renovatebot/github-action@180db1547505e30c02d41959fe65ada1523ee207 # v40.3.0
         with:
           configurationFile: renovate.json5
           token: ${{ steps.app-token.outputs.token }}
+          docker-user: "${{ steps.id.outputs.user }}:${{ steps.id.outputs.group }}"
         env:
           # This enables the cache -- if this is set, it's not necessary to add it to renovate.json.
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -74,6 +74,7 @@ jobs:
           configurationFile: renovate.json5
           token: ${{ steps.app-token.outputs.token }}
           docker-user: "${{ steps.id.outputs.user }}:${{ steps.id.outputs.group }}"
+          docker-volumes: /tmp/renovate:/tmp/renovate
         env:
           # This enables the cache -- if this is set, it's not necessary to add it to renovate.json.
           RENOVATE_REPOSITORY_CACHE: ${{ github.event.inputs.repoCache || 'enabled' }}


### PR DESCRIPTION
ref: https://github.com/renovatebot/github-action/issues/646#issuecomment-2465543441

```log
DEBUG: Using platform gitAuthor: kiba-renovate[bot] <154907007+kiba-renovate[bot]@users.noreply.github.com>
DEBUG: Adding token authentication for api.github.com (hostType=github) to hostRules
DEBUG: Using baseDir: /tmp/renovate
DEBUG: Using cacheDir: /tmp/renovate/cache
DEBUG: Using containerbaseDir: /tmp/renovate/cache/containerbase
FATAL: Fatal error: EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'
       "err": {
         "errno": -13,
         "code": "EACCES",
         "syscall": "mkdir",
         "path": "/tmp/renovate/cache/containerbase",
         "message": "EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'",
         "stack": "Error: EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'"
       }
 INFO: Renovate is exiting with a non-zero code due to the following logged errors
       "loggerErrors": [
         {
           "name": "renovate",
           "level": 60,
           "logContext": "f9smkP2QF64Uoz2kYhyHI",
           "err": {
             "errno": -13,
             "code": "EACCES",
             "syscall": "mkdir",
             "path": "/tmp/renovate/cache/containerbase",
             "message": "EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'",
             "stack": "Error: EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'"
           },
           "msg": "Fatal error: EACCES: permission denied, mkdir '/tmp/renovate/cache/containerbase'"
         }
       ]
Error: The process '/usr/bin/docker' failed with exit code 1
    at ExecState._setResult (/home/runner/work/_actions/renovatebot/github-action/180db1547505e30c02d41959fe65ada1523ee207/dist/index.js:1702:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/renovatebot/github-action/180db1547505e30c02d41959fe65ada1523ee207/dist/index.js:1685:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/renovatebot/github-action/180db1547505e30c02d41959fe65ada1523ee207/dist/index.js:1579:27)
    at ChildProcess.emit (node:events:519:28)
    at maybeClose (node:internal/child_process:1105:16)
    at ChildProcess._handle.onexit (node:internal/child_process:305:5)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a `repoCache` input option for enhanced cache management during workflow execution.
	- Added a step to determine and output the current user and group IDs for better user permissions handling.
	- Implemented new parameters for the `renovatebot/github-action` to improve Docker integration and volume mapping.

- **Improvements**
	- Refined caching mechanism to optimize performance and prevent cache bloat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->