### PR TITLE
ci: add permissions for read access in workflow files

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions: 
+  contents: read
+  packages: read
+
 concurrency:
   group: "cache"
   cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions: 
+  contents: read
+  packages: read
+
 jobs:
   actions-timeline:
     needs: [lint, build, unit-test, e2e-test, ct-test, vrt, tools, chromatic]

--- a/.github/workflows/compare-renovate.yaml
+++ b/.github/workflows/compare-renovate.yaml
@@ -11,6 +11,9 @@ jobs:
     uses: korosuke613/actions/.github/workflows/renovate.yaml@main
     secrets:
       GH_PAT_FOR_RENOVATE: ${{ secrets.GH_PAT_FOR_RENOVATE }}
+    permissions: 
+      contents: read
+      packages: read
 
   actions-timeline:
     needs: call

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -25,6 +25,10 @@ on:
     paths:
       - '.github/workflows/renovate.yaml'
 
+permissions: 
+  contents: read
+  packages: read
+
 concurrency:
   group: renovate
 

--- a/.github/workflows/vrt-init.yaml
+++ b/.github/workflows/vrt-init.yaml
@@ -8,6 +8,10 @@ on:
         required: true
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   vrt-init:
     runs-on: ubuntu-latest
@@ -59,4 +63,4 @@ jobs:
 
       - if: github.event.workflow == '.github/workflows/vrt-init.yaml'
         uses: Kesin11/actions-timeline@3046833d9aacfd7745c5264b7f3af851c3e2a619 # v2.2.1
-        
+


### PR DESCRIPTION
This pull request includes updates to several GitHub Actions workflow files to add permissions for reading contents and packages. These changes ensure that the workflows have the necessary permissions to execute properly.

Permissions updates:

* [`.github/workflows/cache.yaml`](diffhunk://#diff-04c44f0ccda191588a97300b66a9205fe6e56726568a767c546e20d644d24a0fR8-R11): Added `contents: read` and `packages: read` permissions.
* [`.github/workflows/ci.yaml`](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR7-R10): Added `contents: read` and `packages: read` permissions.
* [`.github/workflows/compare-renovate.yaml`](diffhunk://#diff-be5c9267afba21668006517994f70d08d660bf53e5ea694e949de77f9acc3958R14-R16): Added `contents: read` and `packages: read` permissions.
* [`.github/workflows/renovate.yaml`](diffhunk://#diff-f87681f1c7db60655a75838d0610544d4b75e26c6909a97b97f5ec4aa323c7aaR28-R31): Added `contents: read` and `packages: read` permissions.
* [`.github/workflows/vrt-init.yaml`](diffhunk://#diff-c6fe39c4d5b1bbb5116b5007923be27b3deb82d2cbd1a5e37fb9b8dc3846b951R11-R14): Added `contents: read` and `packages: read` permissions.