### PR TITLE
ci: fix default permissions

### DIFF
--- a/.github/workflows/vrt-init.yaml
+++ b/.github/workflows/vrt-init.yaml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  packages: read
 
 jobs:
   vrt-init:


### PR DESCRIPTION
because happened following error

> The workflow is not valid. .github/workflows/pages.yml (Line: 173, Col: 3): Error calling workflow 'korosuke613/homepage-2nd/.github/workflows/vrt-init.yaml@91e239d12ccfe68f61552be0201e39dc02572944'. The workflow is requesting 'packages: read', but is only allowed 'packages: none'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined internal workflow access settings to align with updated operational standards. These adjustments enhance underlying process configurations, ensuring reliable and consistent background operations without affecting visible functionality. End users continue to enjoy stable performance as backend processes are optimized to support robust, secure operations. This update reinforces overall efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->