### PR TITLE
fix: resolve Renovate AI analysis workflow errors and add manual testing

### DIFF
--- a/.github/workflows/bin/renovate-ai-analysis/collect-pr-details.sh
+++ b/.github/workflows/bin/renovate-ai-analysis/collect-pr-details.sh
@@ -42,6 +42,13 @@ main() {
 
 # Collect basic PR information
 collect_pr_info() {
+    # Get PR title if not provided (e.g., for workflow_dispatch)
+    if [[ -z "${PR_TITLE:-}" ]]; then
+        log_info "Fetching PR title..."
+        PR_TITLE=$(gh pr view "${PR_NUMBER}" --json title --jq '.title')
+        log_success "PR title fetched: ${PR_TITLE}"
+    fi
+    
     log_info "Fetching PR body..."
     PR_BODY=$(gh pr view "${PR_NUMBER}" --json body --jq '.body')
     log_success "PR body fetched (${#PR_BODY} characters)"

--- a/.github/workflows/bin/renovate-ai-analysis/utils/logging.sh
+++ b/.github/workflows/bin/renovate-ai-analysis/utils/logging.sh
@@ -4,6 +4,12 @@ set -euo pipefail
 # Logging utilities for Renovate AI Analysis workflow
 # Provides consistent emoji-based logging functions
 
+# Prevent multiple inclusions
+if [[ -n "${LOGGING_UTILS_LOADED:-}" ]]; then
+    return 0
+fi
+readonly LOGGING_UTILS_LOADED=1
+
 # Color codes for terminal output
 readonly RED='\033[0;31m'
 readonly GREEN='\033[0;32m'

--- a/.github/workflows/renovate-ai-analysis.yaml
+++ b/.github/workflows/renovate-ai-analysis.yaml
@@ -35,6 +35,12 @@ on:
   pull_request:
     types: [opened, synchronize]
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to analyze'
+        required: true
+        type: string
 
 jobs:
   ai-analysis:
@@ -43,7 +49,7 @@ jobs:
       pull-requests: write
       models: read
 
-    if: startsWith(github.head_ref, 'renovate/') && github.actor == 'kiba-renovate[bot]'
+    if: (github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/') && github.actor == 'kiba-renovate[bot]') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
@@ -57,8 +63,8 @@ jobs:
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+          PR_TITLE: ${{ github.event.pull_request.title || '' }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           .github/workflows/bin/renovate-ai-analysis/collect-pr-details.sh
@@ -74,7 +80,7 @@ jobs:
             
             Analyze the following PR details and provide a structured response:
             
-            **PR Title:** ${{ github.event.pull_request.title }}
+            **PR Title:** $(cat ${{ steps.pr-details.outputs.TEMP_DIR }}/pr-title.txt)
             
             **PR Description:** $(cat ${{ steps.pr-details.outputs.TEMP_DIR }}/pr-body.txt)
             
@@ -113,7 +119,7 @@ jobs:
         timeout-minutes: 2
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           .github/workflows/bin/renovate-ai-analysis/post-comment.sh "${{ steps.pr-details.outputs.TEMP_DIR }}"


### PR DESCRIPTION
## Summary
- Fix readonly variable redefinition error in logging utilities
- Add workflow_dispatch trigger for manual testing on any PR
- Improve workflow reliability and development experience

## Changes Made
- **Fix logging.sh include guard**: Added `LOGGING_UTILS_LOADED` guard to prevent multiple inclusions and readonly variable redefinition errors
- **Add workflow_dispatch trigger**: Enable manual execution with PR number input for easier testing
- **Update environment variables**: Support both PR events and manual dispatch execution
- **Enhance PR data collection**: Automatically fetch PR title when not provided (manual execution)

## Test Plan
- [x] Syntax validation of all modified shell scripts
- [ ] Test manual workflow execution via GitHub Actions UI
- [ ] Verify original Renovate PR functionality still works
- [ ] Confirm no more "RED: readonly variable" errors

## Technical Details
The original error occurred because `logging.sh` was being sourced multiple times through the dependency chain:
```
collect-pr-details.sh
├── utils/logging.sh
├── utils/file-utils.sh → utils/logging.sh (duplicate)
└── utils/validation.sh → utils/logging.sh (duplicate)
```

This caused bash to attempt redefining readonly variables, resulting in the workflow failure.

🤖 Generated with [Claude Code](https://claude.ai/code)