### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-blogs-data.yaml
+++ b/.github/workflows/update-blogs-data.yaml
@@ -97,6 +97,8 @@ jobs:
       - uses: Kesin11/actions-timeline@3046833d9aacfd7745c5264b7f3af851c3e2a619 # v2.2.1
 
   notify-on-fail:
+    permissions:
+      contents: read
     needs:
       - update
     if: failure()


### PR DESCRIPTION
Potential fix for [https://github.com/korosuke613/homepage-2nd/security/code-scanning/6](https://github.com/korosuke613/homepage-2nd/security/code-scanning/6)

To fix the issue, we will add a `permissions` block to the `notify-on-fail` job. Since this job only needs to notify Slack about a failure, it does not require any write permissions. We will set the permissions to `contents: read`, which is the minimal permission required for most workflows. This ensures adherence to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
