### PR TITLE
ci: allow dependabot for dependency review

### DIFF
--- a/.github/workflows/review-dependency-pr.yaml
+++ b/.github/workflows/review-dependency-pr.yaml
@@ -1,4 +1,5 @@
 name: Review Dependency PR
+run-name: "#${{ github.event.number || github.event.inputs.pr_number }} | Review Dependency PR"
 
 on:
   pull_request:
@@ -17,7 +18,7 @@ permissions:
 
 jobs:
   get-pr-number:
-    if: github.actor == 'renovate[bot]' || github.event_name == 'workflow_dispatch'
+    if: github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.pr_number.outputs.pr_number }}
@@ -32,6 +33,7 @@ jobs:
           fi
 
   review:
+    if: needs.get-pr-number.result == 'success'
     needs: get-pr-number
     uses: korosuke613/review-dependency-pr/.github/workflows/reusable-review-dependency-pr.yml@v0
     with:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved workflow naming in GitHub Actions for clearer identification of dependency review runs.
  - Enhanced workflow to support automated reviews for both Renovate and Dependabot pull requests, as well as manual triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->