### PR TITLE
ci: fix fromJson() empty input error in review dependency PR workflow

### DIFF
--- a/.github/workflows/review-dependency-pr.yaml
+++ b/.github/workflows/review-dependency-pr.yaml
@@ -37,7 +37,7 @@ jobs:
     needs: get-pr-number
     uses: korosuke613/review-dependency-pr/.github/workflows/reusable-review-dependency-pr.yml@v0
     with:
-      pr_number: ${{ fromJson(needs.get-pr-number.outputs.pr_number) }}
+      pr_number: ${{ fromJson(needs.get-pr-number.outputs.pr_number || '0') }} # 文字列を数値に変換。空の場合はデフォルト値0を使用
       review_language: 'ja'
       ai_model: 'openai/gpt-4o'
       max_tokens: 2000


### PR DESCRIPTION
## Summary
- Fix `fromJson()` empty input error in review dependency PR workflow
- Add default value '0' to prevent workflow failure when pr_number output is empty

## Test plan
- [ ] Review dependency PRワークフローが正常に実行されることを確認
- [ ] 空の入力でもエラーが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)