### PR TITLE
chore: Renovateワークフローの動的ユーザー指定と.gitignore改善

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -63,9 +63,9 @@ jobs:
         run: |
           mkdir -p $BASE_DIR
           mkdir -p $CACHE_DIR
-          sudo chown -R runneradmin:root /tmp/renovate/
+          sudo chown -R $(whoami):root /tmp/renovate/
           ls -lR $BASE_DIR
-          echo "user=$(id -u runneradmin)" >> $GITHUB_OUTPUT
+          echo "user=$(id -u)" >> $GITHUB_OUTPUT
           echo "group=$(id -g root)" >> $GITHUB_OUTPUT
 
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ gha-creds-*.json
 db.timestamp-*
 
 .claude/settings.local.json
+
+.envrc


### PR DESCRIPTION
Renovateワークフローで発生していた権限エラーを解決するため、
ハードコーディングされていたユーザー指定を動的取得に変更。
これにより異なるランナー環境でも適切に動作するように改善。

```
Run mkdir -p $BASE_DIR
  mkdir -p $BASE_DIR
  mkdir -p $CACHE_DIR
  sudo chown -R runneradmin:root /tmp/renovate/
  ls -lR $BASE_DIR
  echo "user=$(id -u runneradmin)" >> $GITHUB_OUTPUT
  echo "group=$(id -g root)" >> $GITHUB_OUTPUT
  shell: /usr/bin/bash -e {0}
  env:
    BASE_DIR: /tmp/renovate
    CACHE_DIR: /tmp/renovate/cache/renovate/repository
chown: invalid user: ‘runneradmin:root’
```

🤖 Generated with [Claude Code](https://claude.ai/code)