### PR TITLE
enhance: Add slide support and metadata to RandomArticle feature 

### DIFF
--- a/src/components/RandomArticleCard/RandomArticleCard.stories.tsx
+++ b/src/components/RandomArticleCard/RandomArticleCard.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import type { IPost } from "@/types/IArticleFrontmatter";
 import type { BlogData } from "@/types/IBlogPage";
+import type { SlideData } from "@/types/ISlide";
 import { RandomArticleCard } from "./RandomArticleCard";
 
 const meta: Meta<typeof RandomArticleCard> = {
@@ -67,11 +68,35 @@ const noDescriptionBlog: BlogData = {
   category: ["ブログ"],
 };
 
+const sampleSlide: SlideData = {
+  id: "sample-slide",
+  type: "docswell",
+  title: "サンプルスライド発表",
+  pubDate: "2023-09-10",
+  url: "https://example.com/slides/sample",
+  thumbnailUrl: "https://placehold.jp/ff6600/ffffff/800x450.png",
+  category: ["Docswell"],
+};
+
+const noThumbnailSlide: SlideData = {
+  id: "no-thumbnail-slide",
+  type: "speakerdeck",
+  title: "サムネイルなしのスライド",
+  pubDate: "2023-10-01",
+  url: "https://example.com/slides/no-thumbnail",
+  category: ["SpeakerDeck"],
+};
+
 // 空のモックデータ
 const emptyPosts: IPost[] = [];
 const emptyBlogs: BlogData[] = [];
+const emptySlides: SlideData[] = [];
 
-const defaultRender = (args: { posts: IPost[]; blogs: BlogData[] }) => {
+const defaultRender = (args: {
+  posts: IPost[];
+  blogs: BlogData[];
+  slides: SlideData[];
+}) => {
   return (
     <div
       style={{
@@ -87,6 +112,7 @@ export const Post: Story = {
   args: {
     posts: [samplePost],
     blogs: [],
+    slides: [],
   },
   parameters: {
     docs: {
@@ -100,6 +126,7 @@ export const Blog: Story = {
   args: {
     posts: [],
     blogs: [sampleBlog],
+    slides: [],
   },
   parameters: {
     docs: {
@@ -109,10 +136,25 @@ export const Blog: Story = {
   render: defaultRender,
 };
 
+export const Slide: Story = {
+  args: {
+    posts: [],
+    blogs: [],
+    slides: [sampleSlide],
+  },
+  parameters: {
+    docs: {
+      description: "スライドのみを表示する例",
+    },
+  },
+  render: defaultRender,
+};
+
 export const NoImage: Story = {
   args: {
     posts: [noImagePost],
     blogs: [],
+    slides: [],
   },
   parameters: {
     docs: {
@@ -122,10 +164,25 @@ export const NoImage: Story = {
   render: defaultRender,
 };
 
+export const NoThumbnail: Story = {
+  args: {
+    posts: [],
+    blogs: [],
+    slides: [noThumbnailSlide],
+  },
+  parameters: {
+    docs: {
+      description: "サムネイルがないスライドを表示する例",
+    },
+  },
+  render: defaultRender,
+};
+
 export const NoDescription: Story = {
   args: {
     posts: [],
     blogs: [noDescriptionBlog],
+    slides: [],
   },
   parameters: {
     docs: {
@@ -139,10 +196,11 @@ export const None: Story = {
   args: {
     posts: emptyPosts,
     blogs: emptyBlogs,
+    slides: emptySlides,
   },
   parameters: {
     docs: {
-      description: "記事がない場合の表示",
+      description: "コンテンツがない場合の表示",
     },
   },
   render: defaultRender,
@@ -152,10 +210,11 @@ export const Multiple: Story = {
   args: {
     posts: [samplePost, noImagePost],
     blogs: [sampleBlog, noDescriptionBlog],
+    slides: [sampleSlide, noThumbnailSlide],
   },
   parameters: {
     docs: {
-      description: "複数の記事からランダムに表示する例",
+      description: "複数のコンテンツからランダムに表示する例",
     },
   },
   render: defaultRender,

--- a/src/components/RandomArticleCard/RandomArticleCard.tsx
+++ b/src/components/RandomArticleCard/RandomArticleCard.tsx
@@ -2,11 +2,13 @@ import type React from "react";
 import { useEffect, useState } from "react";
 import type { IPost } from "@/types/IArticleFrontmatter";
 import type { BlogData } from "@/types/IBlogPage";
+import type { SlideData } from "@/types/ISlide";
 import { getRandomArticle, type RandomArticle } from "@/utils/Random";
 
 interface RandomArticleCardProps {
   posts: IPost[];
   blogs: BlogData[];
+  slides: SlideData[];
 }
 
 const initialArticle: RandomArticle = {
@@ -22,23 +24,24 @@ const initialArticle: RandomArticle = {
 export const RandomArticleCard: React.FC<RandomArticleCardProps> = ({
   posts,
   blogs,
+  slides,
 }) => {
   const [isLoading, setIsLoading] = useState(false);
   const [article, setArticle] = useState<RandomArticle>(initialArticle);
 
   useEffect(() => {
-    setArticle(getRandomArticle(posts, blogs));
-  }, [posts, blogs]);
+    setArticle(getRandomArticle(posts, blogs, slides));
+  }, [posts, blogs, slides]);
 
   const handleRefresh = () => {
     setIsLoading(true);
-    setArticle(getRandomArticle(posts, blogs));
+    setArticle(getRandomArticle(posts, blogs, slides));
     setIsLoading(false);
   };
   return (
     <div className="text-center w-full max-w-2xl mx-auto px-4 sm:px-6">
       <h1 className="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">
-        ランダム記事
+        ランダムコンテンツ
       </h1>
 
       <div className="min-h-[400px] sm:min-h-[520px]">
@@ -78,14 +81,18 @@ export const RandomArticleCard: React.FC<RandomArticleCardProps> = ({
 
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mt-auto gap-3 sm:gap-0">
               <span className="bg-blue-900 text-blue-300 px-2 py-1 rounded text-xs sm:text-sm">
-                {article.type === "post" ? "Post" : "Blog"}
+                {article.type === "post"
+                  ? "Post"
+                  : article.type === "blog"
+                    ? "Blog"
+                    : "Slide"}
               </span>
 
               <a
                 href={article.url}
                 className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 sm:py-2 px-4 sm:px-6 rounded transition-colors w-full sm:w-auto text-center"
               >
-                記事を読む
+                {article.type === "slide" ? "スライドを見る" : "記事を読む"}
               </a>
             </div>
           </div>
@@ -94,9 +101,9 @@ export const RandomArticleCard: React.FC<RandomArticleCardProps> = ({
 
       <div className="mb-4 text-gray-400 text-sm">
         <p>
-          総記事数{" "}
+          総コンテンツ数{" "}
           <span className="font-bold text-white">{article.totalCount}</span>{" "}
-          件の中からランダムに表示しています
+          件（記事・ブログ・スライド）の中からランダムに表示しています
         </p>
       </div>
 
@@ -106,7 +113,7 @@ export const RandomArticleCard: React.FC<RandomArticleCardProps> = ({
         disabled={isLoading}
         className={`mt-2 sm:mt-4 bg-slate-700 hover:bg-slate-600 text-white py-2 px-4 rounded transition-colors w-full sm:w-auto ${isLoading ? "opacity-50 cursor-not-allowed" : ""}`}
       >
-        {isLoading ? "読み込み中..." : "別の記事を表示"}
+        {isLoading ? "読み込み中..." : "別のコンテンツを表示"}
       </button>
     </div>
   );

--- a/src/components/RandomArticleCard/RandomArticleCard.tsx
+++ b/src/components/RandomArticleCard/RandomArticleCard.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useEffect, useState } from "react";
+import { ExternalLink } from "@/components/ExternalLink";
 import type { IPost } from "@/types/IArticleFrontmatter";
 import type { BlogData } from "@/types/IBlogPage";
 import type { SlideData } from "@/types/ISlide";
@@ -88,12 +89,11 @@ export const RandomArticleCard: React.FC<RandomArticleCardProps> = ({
                     : "Slide"}
               </span>
 
-              <a
-                href={article.url}
-                className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 sm:py-2 px-4 sm:px-6 rounded transition-colors w-full sm:w-auto text-center"
-              >
-                {article.type === "slide" ? "スライドを見る" : "記事を読む"}
-              </a>
+              <ExternalLink url={article.url} noClass={true}>
+                <span className="bg-blue-600 hover:bg-blue-700 text-white font-bold py-1 sm:py-2 px-4 sm:px-6 rounded transition-colors w-full sm:w-auto text-center block">
+                  {article.type === "slide" ? "スライドを見る" : "記事を読む"}
+                </span>
+              </ExternalLink>
             </div>
           </div>
         </div>

--- a/src/pages/random.astro
+++ b/src/pages/random.astro
@@ -4,15 +4,17 @@ import { RandomArticleCard } from "@/components/RandomArticleCard";
 import { Section } from "@/components/Section";
 import Base from "@/templates/Base.astro";
 import { getSortedBlogData } from "@/utils/Blog";
+import { getSortedSlideData } from "@/utils/Slide";
 
 const posts = await getCollection("posts");
 const blogs = await getSortedBlogData();
+const slides = await getSortedSlideData();
 ---
 
-<Base head={{ title: "ランダム記事", description: "ランダムな記事を表示します", isNoIndex: true }}>
+<Base head={{ title: "ランダムコンテンツ", description: "ランダムなコンテンツ（記事・ブログ・スライド）を表示します", isNoIndex: true }}>
   <Section>
     <div class="flex flex-col items-center justify-center py-10">
-      <RandomArticleCard client:load posts={posts} blogs={blogs}/>
+      <RandomArticleCard client:load posts={posts} blogs={blogs} slides={slides}/>
     </div>
   </Section>
 </Base>

--- a/src/tests/unit/Random.test.ts
+++ b/src/tests/unit/Random.test.ts
@@ -30,38 +30,65 @@ describe("getRandomArticle", () => {
     },
   ];
 
+  const mockSlides = [
+    {
+      id: "slide1",
+      type: "docswell",
+      title: "Test Slide",
+      pubDate: "2023-03-01",
+      url: "https://example.com/slide",
+      thumbnailUrl: "/slide-thumbnail.jpg",
+      category: ["test"],
+    },
+  ];
+
   test("uses a random index when not specified", async () => {
     const mockMath = Object.create(global.Math);
-    mockMath.random = () => 0.25; // Should select index 0 with 2 items
+    mockMath.random = () => 0.25; // Should select index 0 with 3 items
     global.Math = mockMath;
 
-    const result = getRandomArticle(mockPosts, mockBlogs);
+    const result = getRandomArticle(mockPosts, mockBlogs, mockSlides);
 
     expect(result.type).toBe("post");
     expect(result.title).toBe("Test Post");
   });
 
   test("selects a post when articleIndex is 0", () => {
-    const result = getRandomArticle(mockPosts, mockBlogs, { articleIndex: 0 });
+    const result = getRandomArticle(mockPosts, mockBlogs, mockSlides, {
+      articleIndex: 0,
+    });
     expect(result.type).toBe("post");
     expect(result.title).toBe("Test Post");
     expect(result.url).toContain("posts/test-post");
     expect(result.description).toBe("Post description");
     expect(result.imageSrc).toBe("/image.jpg");
-    expect(result.totalCount).toBe(2);
+    expect(result.totalCount).toBe(3);
   });
 
   test("selects a blog when articleIndex is 1", () => {
-    const result = getRandomArticle(mockPosts, mockBlogs, { articleIndex: 1 });
+    const result = getRandomArticle(mockPosts, mockBlogs, mockSlides, {
+      articleIndex: 1,
+    });
     expect(result.type).toBe("blog");
     expect(result.title).toBe("Test Blog");
     expect(result.url).toBe("https://example.com/blog");
     expect(result.imageSrc).toBe("/blog-image.jpg");
-    expect(result.totalCount).toBe(2);
+    expect(result.totalCount).toBe(3);
+  });
+
+  test("selects a slide when articleIndex is 2", () => {
+    const result = getRandomArticle(mockPosts, mockBlogs, mockSlides, {
+      articleIndex: 2,
+    });
+    expect(result.type).toBe("slide");
+    expect(result.title).toBe("Test Slide");
+    expect(result.url).toBe("https://example.com/slide");
+    expect(result.imageSrc).toBe("/slide-thumbnail.jpg");
+    expect(result.totalCount).toBe(3);
   });
 
   test("returns error info when no articles are available", () => {
-    const result = getRandomArticle([], [], { articleIndex: 0 });
+    const result = getRandomArticle([], [], [], { articleIndex: 0 });
     expect(result.type).toBe("post");
     expect(result.title).toBe("記事が見つかりませんでした");
     expect(result.url).toBe("");
@@ -69,9 +96,11 @@ describe("getRandomArticle", () => {
   });
 
   test("returns error info when index is out of bounds", () => {
-    const result = getRandomArticle(mockPosts, mockBlogs, { articleIndex: 10 });
+    const result = getRandomArticle(mockPosts, mockBlogs, mockSlides, {
+      articleIndex: 10,
+    });
     expect(result.title).toBe("記事が見つかりませんでした");
     expect(result.url).toBe("");
-    expect(result.totalCount).toBe(2);
+    expect(result.totalCount).toBe(3);
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Random content now includes slides in addition to posts and blogs.
  - Added type-specific labeling and actions (e.g., “スライドを見る” for slides).
- UI
  - Updated headings and labels from “記事” to “コンテンツ” across the random content card and page.
  - Counts now reflect total content (posts, blogs, slides).
- Documentation
  - Storybook updated with slide-supported stories, including examples for slides-only and slides without thumbnails.
- Tests
  - Updated random selection tests for slides.
  - Removed legacy slide component and utility test suites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->