### PR TITLE
refactor: GitHub ActionsのPlaywrightセットアップを共通化

### DIFF
--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -23,7 +23,7 @@ runs:
     - name: Install playwright
       shell: bash
       run: |
-        # Skip installing pacakge docs {makes the man-db trigger much faster) 
+        # Skip installing package docs (makes the man-db trigger much faster) 
         # (I disabled `/doc` and `/info` too, just in case.)
         # ref: https://github.com/actions/runner-images/issues/10977#issuecomment-2810713336
         sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'

--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -1,0 +1,35 @@
+name: Setup Playwright action
+description: "Install Playwright browsers with caching"
+
+
+runs:
+  using: "composite"
+  steps:
+    - name: Get Playwright version
+      id: get-playwright-version
+      shell: bash
+      run: |
+        PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
+        echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+
+    - name: Cache playwright binaries
+      uses: actions/cache@v4
+      id: playwright-cache
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ steps.get-playwright-version.outputs.PLAYWRIGHT_VERSION }}
+        restore-keys: playwright-
+
+    - name: Install playwright
+      shell: bash
+      run: |
+        # Skip installing pacakge docs {makes the man-db trigger much faster) 
+        # (I disabled `/doc` and `/info` too, just in case.)
+        # ref: https://github.com/actions/runner-images/issues/10977#issuecomment-2810713336
+        sudo tee /etc/dpkg/dpkg.cfg.d/01_nodoc > /dev/null << 'EOF'
+        path-exclude /usr/share/doc/*
+        path-exclude /usr/share/man/*
+        path-exclude /usr/share/info/*
+        EOF
+
+        npx playwright install chromium --with-deps

--- a/.github/actions/setup-playwright/action.yaml
+++ b/.github/actions/setup-playwright/action.yaml
@@ -20,6 +20,42 @@ runs:
         key: playwright-${{ steps.get-playwright-version.outputs.PLAYWRIGHT_VERSION }}
         restore-keys: playwright-
 
+    - name: Configure multiple high-speed mirrors
+      shell: bash
+      run: |     
+        # 既存の設定を確認
+        echo "=== Current mirror configuration ==="
+        cat /etc/apt/sources.list.d/ubuntu.sources
+        echo "------------------------------------"
+
+        # GitHub Actionsに最適化されたミラー設定
+        sudo tee /etc/apt/sources.list.d/ubuntu.sources << EOF
+        Types: deb
+        URIs: http://mirrors.kernel.org/ubuntu/ http://mirror.math.princeton.edu/pub/ubuntu/ http://ftp.ussg.iu.edu/linux/ubuntu/ http://archive.ubuntu.com/ubuntu/
+        Suites: $(lsb_release -cs) $(lsb_release -cs)-updates $(lsb_release -cs)-backports
+        Components: main restricted universe multiverse
+        Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+        
+        Types: deb
+        URIs: http://archive.ubuntu.com/ubuntu/
+        Suites: $(lsb_release -cs)-security
+        Components: main restricted universe multiverse
+        Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+        EOF
+        
+        # ネットワーク最適化
+        sudo tee /etc/apt/apt.conf.d/99-github-actions << EOF
+        Acquire::http::Timeout "3";
+        Acquire::https::Timeout "3";
+        Acquire::Retries "1";
+        Acquire::Queue-Mode "access";
+        EOF
+        
+        echo "=== New mirror configuration ==="
+        cat /etc/apt/sources.list.d/ubuntu.sources | head -5
+        
+        sudo apt-get update
+
     - name: Install playwright
       shell: bash
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -198,22 +198,11 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        id: npm-install
-        run: |
-          npm ci
-          PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+        run: npm ci
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-
-      - name: Install playwright
-        run: npx playwright install chromium --with-deps
+      - name: Setup Playwright
+        timeout-minutes: 3
+        uses: ./.github/actions/setup-playwright
 
       - name: E2E testing
         run: npm run test:playwright-e2e -- --retries=2 --workers=2
@@ -236,22 +225,11 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        id: npm-install
-        run: |
-          npm ci
-          PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+        run: npm ci
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-  
-      - name: Install playwright
-        run: npx playwright install chromium --with-deps
+      - name: Setup Playwright
+        timeout-minutes: 3
+        uses: ./.github/actions/setup-playwright
 
       - name: Component testing
         run: npm run test:playwright-ct

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -45,6 +45,4 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Setup Playwright
-        timeout-minutes: 3
-        uses: ./.github/actions/setup-playwright
+      # copilot は playwright mcp を標準搭載しているため、playwright のセットアップは不要

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -43,19 +43,8 @@ jobs:
           cache: "npm"
 
       - name: Install dependencies
-        id: npm-install
-        run: | 
-          npm ci
-          PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+        run: npm ci
 
-      - name: Restore playwright binaries cache 
-        uses: actions/cache/restore@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-
-      - name: Install playwright
-        run: npx playwright install chromium --with-deps
+      - name: Setup Playwright
+        timeout-minutes: 3
+        uses: ./.github/actions/setup-playwright

--- a/.github/workflows/vrt-init.yaml
+++ b/.github/workflows/vrt-init.yaml
@@ -26,22 +26,11 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        id: npm-install
-        run: |
-          npm ci
-          PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
+        run: npm ci
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-
-      - name: Install playwright
-        run: npx playwright install chromium --with-deps
+      - name: Setup Playwright
+        timeout-minutes: 3
+        uses: ./.github/actions/setup-playwright
       
       - name: Run VRT init
         run: |

--- a/.github/workflows/vrt-init.yaml
+++ b/.github/workflows/vrt-init.yaml
@@ -28,8 +28,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # main ブランチでの実行を前提としており、VRT のオラクルを確実に作りたいため、timeout は設定しない
       - name: Setup Playwright
-        timeout-minutes: 3
         uses: ./.github/actions/setup-playwright
       
       - name: Run VRT init

--- a/.github/workflows/vrt-regression.yaml
+++ b/.github/workflows/vrt-regression.yaml
@@ -56,31 +56,15 @@ jobs:
 
       - name: Install dependencies
         if: ${{ !inputs.skip }}
+        run: npm ci
 
-        id: npm-install
-        run: |
-          npm ci
-          PLAYWRIGHT_VERSION=$(npm ls --json @playwright/test | jq --raw-output '.dependencies["@playwright/test"].version')
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
-
-      - name: Cache playwright binaries
+      - name: Setup Playwright
+        timeout-minutes: 3
         if: ${{ !inputs.skip }}
-
-        uses: actions/cache@v4
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-  
-      - name: Install playwright
-        if: ${{ !inputs.skip }}
-
-        run: npx playwright install chromium --with-deps
+        uses: ./.github/actions/setup-playwright
 
       - name: Cache VRT snapshots
         if: ${{ !inputs.skip }}
-
         uses: actions/cache@v4
         id: vrt-cache
         with:
@@ -89,7 +73,6 @@ jobs:
 
       - name: Check snapshot exists
         if: ${{ !inputs.skip }}
-
         run: |
           if [[ -z "$(ls -A src/tests/vrt/snapshots)" ]]; then
             echo "### ⚠️ No snapshot exists" >> $GITHUB_STEP_SUMMARY
@@ -100,7 +83,6 @@ jobs:
 
       - name: Visual regression testing
         if: ${{ !inputs.skip }}
-
         run: |
           if [[ -z "${{ steps.changed-files.outputs.contents_all_changed_and_modified_files }}" ]]; then
             # コンテンツの変更がない


### PR DESCRIPTION
複数のワークフローファイルで重複していたPlaywrightのキャッシュ
とインストール処理を統一：

- .github/actions/setup-playwright アクションを使用するよう変更
- 各ワークフローから重複コードを削除
- タイムアウト設定を追加 (3分)

対象ワークフローファイル:
- ci.yaml (E2Eテストおよびコンポーネントテスト)
- copilot-setup-steps.yml
- vrt-init.yaml
- vrt-regression.yaml

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Playwright setup into a reusable CI action and replaced per-workflow multi-step setup.
  * Simplified dependency steps by removing inline version-detection and moving Playwright setup to the shared action.
  * Applied short timeouts to the Playwright setup step in some workflows.

* **Performance**
  * Browser-binary caching and mirror configuration are centralized in the shared action to speed and stabilize CI setup.

* **Tests**
  * More consistent E2E, component, and visual-regression environments, improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->