### PR TITLE
fix: allow bot trigger for dependency review workflow

### DIFF
--- a/.github/workflows/review-dependency-pr.yaml
+++ b/.github/workflows/review-dependency-pr.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: kiba-renovate,dependabot[bot]
+          allowed_bots: kiba-renovate[bot],dependabot[bot]
           additional_permissions: |
             actions: read
           prompt: |

--- a/.github/workflows/review-dependency-pr.yaml
+++ b/.github/workflows/review-dependency-pr.yaml
@@ -53,6 +53,7 @@ jobs:
         with:
           github_token: ${{ steps.login-gh-app.outputs.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: kiba-renovate,dependabot[bot]
           additional_permissions: |
             actions: read
           prompt: |


### PR DESCRIPTION
## Why
`review-dependency-pr` workflow started failing after `anthropics/claude-code-action` began requiring explicit bot allowlisting. Renovate-triggered runs were rejected with `Workflow initiated by non-human actor`.

## What changed
Added `allowed_bots: kiba-renovate,dependabot[bot]` to the Claude Code Action step in `.github/workflows/review-dependency-pr.yaml`.

## Notes
This change is intentionally limited to the dependency review workflow. `.github/workflows/claude-code-action.yaml` remains human-triggered and does not allow bot actors.