### PR TITLE
ci: overlap network-bound steps with build/test in cache workflow

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
 
-permissions: 
+permissions:
   contents: read
   packages: read
 
@@ -38,7 +38,40 @@ jobs:
           PLAYWRIGHT_VERSION=$(pnpm ls @playwright/test --json | jq -r '.[].devDependencies."@playwright/test".version')
           echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
 
+      # 並行起動するステップが依存するキャッシュ復元・setup を先に foreground で済ませる。
+      - name: Cache playwright binaries
+        uses: actions/cache@v5
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
+          restore-keys: playwright-
+
+      - name: Cache astro build
+        uses: actions/cache@v5
+        with:
+          path: .astro/cache
+          key: astro-build-${{ github.sha }}
+          restore-keys: astro-build-
+
+      - name: Cache Vitest
+        uses: actions/cache@v5
+        with:
+          path: .cache/.vitest
+          key: vitest-${{ github.sha }}
+          restore-keys: vitest-
+
+      - name: Cache node_modules of tools
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: '.tool-versions'
+          cache: 'pnpm'
+          cache-dependency-path: 'tools/pnpm-lock.yaml'
+
+      # ネットワーク/IO 律速の処理を background で並走させ、その裏で
+      # CPU 律速の Build / Vitest を進めることで待ち時間を重ねる。
       - name: Publish to Chromatic
+        background: true
         uses: chromaui/action@1bbb5819252d9782cb7d77122d9becae467def18 # v16.10.1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
@@ -48,37 +81,27 @@ jobs:
           traceChanged: true
           debug: true
 
-      - name: Cache playwright binaries
-        uses: actions/cache@v5
-        id: playwright-cache
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ steps.npm-install.outputs.PLAYWRIGHT_VERSION }}
-          restore-keys: playwright-
-
       - name: Install playwright
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium --with-deps
+        background: true
+        run: pnpm exec playwright install chromium --with-deps
 
-      - name: Cache astro build
-        uses: actions/cache@v5
-        with:
-          path: .astro/cache
-          key: astro-build-${{ github.sha }}
-          restore-keys: astro-build-
+      - name: Install dependencies of tools
+        background: true
+        working-directory: tools
+        run: |
+          pnpm install --frozen-lockfile
 
+      # CPU 律速の処理（同士の競合を避けるため Build → Vitest は直列のまま）。
       - name: Build
         run: pnpm run build
 
-      - name: Cache Vitest
-        uses: actions/cache@v5
-        with:
-          path: .cache/.vitest
-          key: vitest-${{ github.sha }}
-          restore-keys: vitest-
-      
       - name: Vitest
         run: pnpm run test:unit
+
+      # background のネットワーク処理（Chromatic / playwright / tools install）の完了を待つ。
+      - name: Wait for background tasks
+        wait-all: true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
@@ -86,15 +109,3 @@ jobs:
           flags: unittests
           token: ${{ secrets.CODECOV_TOKEN }}
         if: always()
-
-      - name: Cache node_modules of tools
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.tool-versions'
-          cache: 'pnpm'
-          cache-dependency-path: 'tools/pnpm-lock.yaml'
-
-      - name: Install dependencies of tools
-        working-directory: tools
-        run: |
-          pnpm install --frozen-lockfile


### PR DESCRIPTION
## 概要

GitHub Actions の新機能「[ステップの並行/非同期実行](https://github.blog/changelog/2026-06-25-actions-steps-can-now-be-run-in-parallel/)」（`background` / `wait-all`）を `cache.yaml` に適用し、これまで単一ジョブ内で全ステップを直列実行していた構成を最適化します。

ネットワーク/IO 律速の処理を `background: true` で並走させ、その裏で CPU 律速の Build / Vitest を進めることで待ち時間を重ねます。

## 変更点

- **background 化**: Chromatic 発行 / Playwright インストール / tools 依存インストール（いずれもネットワーク/IO 律速）
- **並べ替え**: background ステップが依存するキャッシュ復元・`setup-node` を前方の foreground へ移動
- **バリア**: Codecov アップロード前に `wait-all` で background 処理を合流
- Build → Vitest は CPU 競合回避のため直列を維持
- `npx playwright install` → `pnpm exec playwright install`（package.json 固定版の利用）

## 設計意図

CPU と IO は奪い合う資源が異なるため、CPU 処理（build/test）の裏で IO 処理（アップロード・ダウンロード・install）を流すと、相殺なく待ち時間を隠せます。

## 検証 / 注意点

- ✅ YAML 構文チェック済み（js-yaml）
- ⚠️ `background` / `wait-all` は公開直後（2026-06-25）の新機能のため、以下は本 PR 反映後の実機（main push）で要確認:
  - background のいずれかが失敗したとき `wait-all` でジョブが赤くなるか（**exit code 伝播**）
  - `background` が `uses:` アクション（Chromatic）にも効くか
- 本ワークフローは `main` push 時のキャッシュ温め用で PR をゲートしないため、挙動差異の影響は限定的です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)